### PR TITLE
Ruby FFI compatibility layer

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,6 +5,12 @@ MRuby::Gem::Specification.new('mruby-cfunc') do |spec|
   spec.authors = 'MobiRuby developers'
   
   spec.rbfiles = Dir[File.expand_path('../mrblib/**/*.rb', __FILE__)]
+  spec.rbfiles = [
+    'cfunc_rb',
+    'ffi/argument',
+    'ffi/function',
+    'ffi/ffi'
+  ].map{|path| File.expand_path("../mrblib/#{path}.rb", __FILE__) }
 
   def spec.use_pkg_config(pkg_config='pkg-config')
     self.linker.flags << `"#{pkg_config}" libffi --libs-only-L --libs-only-other`.chomp

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -3,6 +3,8 @@ require 'open-uri'
 MRuby::Gem::Specification.new('mruby-cfunc') do |spec|
   spec.license = 'MIT'
   spec.authors = 'MobiRuby developers'
+  
+  spec.rbfiles = Dir[File.expand_path('../mrblib/**/*.rb', __FILE__)]
 
   def spec.use_pkg_config(pkg_config='pkg-config')
     self.linker.flags << `"#{pkg_config}" libffi --libs-only-L --libs-only-other`.chomp

--- a/mrblib/cfunc_rb.rb
+++ b/mrblib/cfunc_rb.rb
@@ -188,6 +188,11 @@ class CFunc::Struct
         self.new(pointer)
     end
     
+    def element(fieldname)
+        field = lookup(fieldname)
+        field[0].refer(@pointer.offset(field[2]))
+    end
+    
     def [](fieldname)
         field = lookup(fieldname)
         el = field[0].refer(@pointer.offset(field[2]))

--- a/mrblib/ffi/argument.rb
+++ b/mrblib/ffi/argument.rb
@@ -1,0 +1,233 @@
+module FFIType2CFuncType
+  # Returns a Class of CFunc namespace types
+  def ffi_type
+    case type
+    when :object
+      CFunc::Pointer
+    when :struct
+      CFunc::Pointer
+    when :union
+      CFunc::Pointer
+    when :array
+      CFunc::CArray(array.ffi_type)
+    else
+      FFI::TYPES[type] || CFunc::Pointer
+    end
+  end
+end
+
+# Represents Argument/Return array member
+# specifies properties of the array
+class ArrayStruct < Struct.new(:length,:fixed_size,:type,:enum,:zero_terminated)
+end
+
+
+class ClosureStruct < Struct.new(:return_type,:arguments)
+end
+
+module Cvalue2RubyValue
+  # Converts a C value to Ruby from information of a (Argument || Return)
+  def to_ruby ptr,len=nil
+    if array
+      if !len
+        len = array.length
+      end
+     
+      if len < 0
+        len = array.fixed_size
+      end    
+     
+      a = []
+      tt = type == :array ? array.type : type
+      #if !array.zero_terminated
+  	    if tt == :enum
+		  ptr.send :"read_array_of_#{:int}",len do |q|
+		    a << q
+		  end
+		  return a
+	    else
+		  ptr.send :"read_array_of_#{tt}",len do |q|
+		    a << q
+		  end
+		  return a
+	    end
+      #else
+
+      #end
+    elsif type == :pointer
+      return ptr
+    elsif type == :enum
+      r = ptr.send :"read_int"
+      return r if r == -1
+      return enum.enum?[r]
+    elsif type == :object or type == :struct
+      ns = object[:namespace]
+      name = object[:name]
+      return ::Object.const_get(ns).const_get(name).wrap ptr
+    else 
+      tt = type
+      return ptr.send(:"read_#{tt}")  
+    end
+  end
+  
+  # true if type is a C numeric type
+  def is_numeric?
+    FFI::C_NUMERICS.index(FFI::TYPES[type])
+  end
+  
+  # Converts Symbol to Integer
+  # if v is a member of the (Argument || Return)#enum
+  def get_enum v
+    r = enum.enum?
+    if r
+      r = r.map do |v| v.name.to_sym end
+    end
+    r.index(v)
+  end
+end 
+
+# Represents Argument information
+# and defines ways to create and convert
+# Arguments to/from c
+class Argument < Struct.new(:object,:type,:struct,:array,:direction,:allow_null,:callback,:closure,:destroy,:value,:index,:enum)
+  # Sets value from an argument passed to Function#invoke
+  def set v
+    self[:value] = v
+  end
+  
+  include FFIType2CFuncType
+  
+  # Resolve and create the appropiate 
+  # pointer from Argument properties for Function#invoke
+  def make_pointer mul = 1
+    if type == :callback
+      if value.is_a?(CFunc::Closure)
+        return value
+      elsif cb=FFI::Library.callbacks[callback]
+        return FFI::Closure.add callback,cb[1],cb[0]
+      else
+        return FFI::DefaultClosure.new
+      end
+    elsif array
+      ptr = CFunc::Pointer.malloc(4)
+      return FFI::MemoryPointer.refer(ptr)
+    else
+      tt = FFI::TYPES[type] ? type : :pointer
+      
+       q=FFI::MemoryPointer.new(tt,mul)
+      return q#FFI::MemoryPointer.new(tt,mul)
+    end
+  end
+  
+  include Cvalue2RubyValue
+  
+  # Sets the appropiate value for an Argument for Function#invoke
+  def for_invoke
+    if type == :string and direction == :in
+      return value
+    end
+    
+    if type == :pointer
+      if value.is_a?(CFunc::Pointer)
+        return value
+      end
+    elsif type == :object
+        return value
+    end
+    
+    ptr = make_pointer
+
+    if type == :callback
+      ptr.set_closure value if ptr.respond_to?(:set_closure)
+      return ptr
+    end
+    
+    tt = type
+    
+    tt = (tt == :enum ? :int : tt)
+    
+    if value;
+      q = value
+      if type == :enum
+        if value.is_a?(Symbol)
+          q = get_enum(value)
+        end
+      end
+      
+      if type == :pointer
+        unless q.is_a?(CFunc::Pointer)
+          if q == 0
+            q = CFunc::Int.new(0)
+          end
+        end
+      end
+
+      if array
+        tt = array.type
+        meth = :"write_array_of_#{tt}"
+      else
+        meth = :"write_#{tt}"
+      end
+
+      ptr.send meth,q unless direction == :out
+
+    elsif allow_null or omit?
+      ptr.write_int 0 unless direction == :out
+    end
+ 
+    return ptr
+  end
+ 
+  # Returns true if the argument may be omitted from invoke arguments
+  # The argument will be automatically resolved to nil
+  # Callbacks are resolved to passed block of Function#invoke or nil
+  def omit?
+    (type == :destroy) || (type == :error) || (type == :callback) || (type == :data) || (direction == :out)
+  end
+  
+  # Returns  true if the argument is allowed to be null
+  # may be ommitted from arguments to Function#invoke
+  def optional?
+    allow_null
+  end
+end
+
+
+# Represents information of a return_value of Function#invoke
+class Return < Struct.new(:object,:type,:struct,:array,:enum)
+  include FFIType2CFuncType
+  
+  def get_c_type
+    if type == :enum
+      CFunc::Int
+    elsif type == :object
+      CFunc::Pointer
+    else
+      FFI::TYPES[type]
+    end
+  end
+  
+  include Cvalue2RubyValue
+  
+  # returns a Ruby value of the passes ptr
+  # resolved from Return properties
+  def to_ruby ptr,len=1
+    if FFI::C_NUMERICS.index(ptr.class)
+      if type == :bool
+        ptr.value == 1
+      else
+        n = ptr.value
+  
+        if type == :enum
+          return enum.enum?[n]
+        end
+  
+        return n
+      end
+    else
+      ptr = FFI::Pointer.refer(ptr.addr)
+      q=super ptr,len
+      return q
+    end
+  end
+end

--- a/mrblib/ffi/ffi.rb
+++ b/mrblib/ffi/ffi.rb
@@ -1,0 +1,388 @@
+
+module FFI
+ C_NUMERICS = [CFunc::Int,
+              CFunc::SInt8,
+              CFunc::SInt16,
+              CFunc::SInt32,
+              CFunc::SInt64,
+              CFunc::UInt32,
+              CFunc::UInt8,
+              CFunc::UInt16,
+              CFunc::UInt32,
+              CFunc::UInt64,
+              CFunc::Float,
+              CFunc::Double]
+  TYPES = {
+    :self => :pointer,
+    :int=>CFunc::Int,
+    :uint=>CFunc::UInt32,
+    :bool=>CFunc::Int,
+    :string=>CFunc::Pointer,
+    :pointer=>CFunc::Pointer,
+    :void=>CFunc::Void,
+    :double=>CFunc::Double,
+    :size_t=>CFunc::UInt32,
+    :ulong=>CFunc::UInt64,
+    :long=>CFunc::SInt64,
+    :uint64=>CFunc::UInt64,
+    :uint8=>CFunc::UInt8,
+    :uint16=>CFunc::UInt16,
+    :uint32=>CFunc::UInt32,
+    :int64=>CFunc::SInt64,
+    :int16=>CFunc::SInt16,
+    :int8=>CFunc::SInt8,
+    :int32=>CFunc::Int,
+    :short=>CFunc::SInt16,
+    :ushort=>CFunc::UInt16,
+    :callback=>CFunc::Closure,
+    :struct=>CFunc::Pointer,
+    :array=>CFunc::CArray
+  }
+
+end
+
+module CFunc
+  define_function CFunc::Pointer,"dlopen",[CFunc::Pointer,CFunc::Int]
+  class Library
+    @@instances = {}
+    def initialize where
+      @funcs = {}
+      @@instances[where] = self
+      @libname=where
+      if @libname.to_s == 'c'
+        @libname = nil
+      end
+      
+      @dlh = CFunc::call(CFunc::Pointer, "dlopen", @libname, CFunc::Int.new(1))
+    end
+
+    def call rt,name,*args
+      # @dlh ||= CFunc[:dlopen].call(@libname,CFunc::Int.new(1))
+      if !(f=@funcs[name])
+        fun_ptr = CFunc::call(CFunc::Pointer,:dlsym,@dlh,name)
+        f = CFunc::FunctionPointer.new(fun_ptr)
+        f.result_type = rt
+        @funcs[name] = f
+      end
+      
+      f.arguments_type = args.map do |a| a.class end      
+      return f.call(*args)
+    end
+    
+    def self.for where
+      if n=@@instances[where]
+        n
+      else
+        return new(where)
+      end
+    end
+  end
+  
+  def self.libcall2 rt,where,n,*o
+    return CFunc::Library.for(where).call rt,n,*o
+  end
+end
+
+
+module FFI; 
+  class FFI::Closure < CFunc::Closure
+    CLOSURES = {}
+  
+    def initialize *o,&b
+      @block = b
+      super(*o) do |*a|
+        @block.call(*a)
+      end
+    end
+    
+    def set_closure b
+      @block = b
+    end
+    
+    def self.add name,rt,at,&b
+      return FFI::Closure::CLOSURES[name] ||= FFI::Closure.new(rt,at,&b)
+    end
+  end
+  
+  class DefaultClosure < FFI::Closure
+    def initialize &b
+      super CFunc::Void,[],&b
+    end
+  end
+end
+
+
+class FFI::Pointer < CFunc::Pointer
+  def self.new(*args)
+    if args.size == 1
+      new(args[0])
+    else
+      type, ptr = args
+      CFunc::Pointer(type).refer(ptr.addr)
+    end
+  end
+  
+  def write_array_of type,a
+    ca = CFunc::CArray(TYPES[type]).refer(self.addr)
+
+    a.each_with_index do |q,i|
+      ca[i].value = q
+    end
+    return self
+  end
+  
+  def read_void
+    nil
+  end
+  
+  def read_array_of type,len
+    ca = CFunc::CArray(TYPES[type]).refer(self.addr)
+    (0...len).map do |i|
+      type == :pointer ? FFI::Pointer.refer(ca[i].value.addr) : ca[i].value
+    end 
+  end
+  
+  def write_array_of_string sa
+    ca = CFunc::CArray(CFunc::Pointer).refer(self.addr)
+    subt = 0
+    
+    sa.each_with_index do |q,i|
+      ia = CFunc::SInt8[q.length]
+      c = 0
+      
+      q.each_byte do |b|
+        ia[c].value = b
+        c += 1
+      end
+      
+      ia[c].value = 0
+      ca[i].value = ia
+    end
+    return self
+  end
+  
+  def read_array_of_string len
+    read_array_of :pointer,len do |y|
+      yield CFunc::CArray(CFunc::SInt8).refer(y.addr).to_s
+    end
+  end
+  
+  def get_pointer offset
+    FFI::Pointer.refer(self[offset].addr)
+  end
+  
+  def read_string
+    value.to_s
+  end
+  
+  def write_string(str)
+    CFunc::call(CFunc::Pointer, "strcpy", self, str)
+    # ca = CFunc::CArray(CFunc::SInt8).refer(self.addr)
+    # c = 0
+    
+    # s.each_byte do |b|
+    #   ca[c].value = b
+    #   c += 1
+    # end
+    
+    # ca[c].value = 0
+    return self
+  end
+  
+  def read_type type
+    return TYPES[type].get(self)
+  end
+  
+  def write_type n,type
+    TYPES[type].set(self, n)
+    return self
+  end
+  
+  FFI::TYPES.keys.each do |k|
+    unless k == :string or k == :array
+      define_method :"read_#{k}" do
+        next read_type k
+      end
+
+      define_method :"write_#{k}" do |v|
+        next write_type v,k
+      end
+      define_method :"write_array_of_#{k}" do |v|
+        next write_array_of k,v
+      end  
+      define_method :"read_array_of_#{k}" do |v,&b|
+        next read_array_of(k,v)
+      end            
+    end
+  end
+  
+  def read_bool
+    return read_int == 1
+  end
+  
+  def read_array_of_bool len
+    read_array_of_int len do |i|
+      yield i == 1
+    end
+    return nil
+  end
+end
+  
+class FFI::MemoryPointer < FFI::Pointer
+  def self.new *o
+    count = 1
+    clear = false
+    
+    if o.length == 1
+      size = o[0]
+      if size.is_a?(Numeric)
+        return malloc(size)
+      end
+    elsif o.length == 2
+      size, count = o
+    elsif o.length == 3
+      size,count,clear = o
+    else
+      raise "arguments error > 4 for 1..3"
+    end
+    
+    s = TYPES[size].size
+    ins = malloc(s*count)
+
+    return ins
+  end  
+end
+
+module FFI
+  class Struct < CFunc::Struct
+    def self.members
+      elements.map{|e| e[1] }
+    end
+    
+    def self.is_struct?
+      true
+    end
+    def self.every(a,i)
+      b=[]
+      q=a.clone
+      d=[]
+      c=0
+      until q.empty?
+        for n in 0..i-1
+          d << q.shift
+        end
+
+        d[1] = FFI.find_type(d[1]) unless d[1].respond_to?(:"is_struct?")
+        b.push(*d.reverse)
+        d=[]
+      end
+      b
+    end
+  
+    def self.layout *o
+      define(*every(o,2))
+    end
+  end
+  class Union < Struct
+  end  
+  
+  def self.type_size t
+    return FFI::TYPES[t].size
+  end
+end
+
+class Array
+  def find_all_indices a=self,&b
+    o = []
+    a.each_with_index do |q,i|
+      if b.call(q)
+        o << i
+      end
+    end
+    return o
+  end
+  
+  def flatten
+    a=[]
+    each do |q|
+      a.push(*q)
+    end
+    return a
+  end  
+end
+
+
+
+
+module FFI::Library
+  def ffi_lib n=nil
+    @ffi_lib = n if n
+    return @ffi_lib
+  end
+  
+  @@callbacks = {}
+  
+  def callback n,at,rt
+    return @@callbacks[n] = [at.map do |t| FFI::TYPES[t] end,FFI::TYPES[rt]]
+  end
+  
+  def self.callbacks
+    return @@callbacks
+  end
+  
+
+  
+  def typedef *o
+    return FFI::TYPES[o[1]] = q=FFI.find_type(o[0])
+  end  
+  
+    @@enums = {}
+    def enum t,a
+      if a.find() do |q| q.is_a?(Integer) end
+        b = []
+ 
+        for i in 0..((a.length/2)-1)
+          val= a[i*2] 
+          idx = a[(i*2)+1]
+          b[idx] = val
+        end
+
+        a=b
+      end
+      @@enums[t] = a
+      typedef :int,t
+      return self
+    end
+
+    def self.enums
+      r=@@enums
+      return r
+    end  
+  
+  def attach_function name,at,rt
+    f=add_function ffi_lib,name,at,rt
+
+    self.class_eval do
+      class << self;self;end.define_method name do |*o,&b|  
+        next f.invoke(*o,&b)
+      end
+    end
+    return self
+  end
+end
+
+module FFI
+  def self.errno
+    return CFunc.errno
+  end
+  
+  def self.find_type t
+    return FFI::TYPES[t] || CFunc::Pointer
+  end  
+end
+
+class Symbol
+  def enum?
+    return FFI::Library.enums[self]
+  end
+end

--- a/mrblib/ffi/function.rb
+++ b/mrblib/ffi/function.rb
@@ -1,0 +1,350 @@
+class Function
+  attr_reader :return_type
+
+  def initialize where,name,args,return_type,results=[-1]
+    @arguments = args
+    @where = where
+    @name = name
+    @return_type = return_type
+    @results = results
+  end
+  
+  def set_closure closure
+    @closure = closure
+  end
+  
+  
+	def get_return_type
+	  return @return_type.get_c_type
+	end
+    
+  def get_omits
+    oa = arguments.find_all do |a|
+      a.omit?
+    end
+    
+    oidxa = oa.map do |o|
+      arguments.index o
+    end
+    
+    return oidxa
+  end
+  
+  def get_optionals
+    oa = arguments.find_all do |a|
+      a.optional?
+    end
+    
+    oidxa = oa.map do |o|
+      arguments.index o
+    end
+    
+    return oidxa
+  end
+
+  def get_required
+    a=arguments.find_all do |a|
+      !a.omit? and !a.optional?
+    end
+    
+    oidxa = a.map do |o|
+      arguments.index o
+    end
+    
+    return oidxa
+  end
+  
+  def get_rargs
+    map = arguments.find_all do |a| !a.omit? end.map do |a| arguments.index a end
+    return map
+  end
+  
+  def get_optionals_start
+    oa = get_optionals
+    
+    get_required.each do |r|
+      oa.find_all do |o|
+        o < r
+      end.each do |i|
+        oa.delete(i)
+      end
+    end
+    
+    return oa.first
+  end
+  
+  def get_args_to_return
+    map = arguments.find_all do |a| a.direction == :out end.map do |a| arguments.index(a) end.map do |i|
+      arguments[i]
+    end
+    
+    return map
+  end
+  
+  attr_reader :arguments
+  def invoke *args,&b
+
+    have = args.length
+    required = len=get_required.length
+    max = len+get_optionals.length
+    rargs = []
+
+    args.each_with_index do |a,i|
+      if a.respond_to?(:to_ptr)
+        args[i] = a.to_ptr
+      end
+      rargs << get_rargs[i]
+    end 
+    
+    if idx = get_optionals_start
+      required += get_optionals.find_all do |o|
+        o < idx
+      end.length
+    end
+    
+    raise "Too few arguments. #{have} for #{required}..#{max}" if have < required
+    raise "Too many arguments. #{have} for #{required}..#{max}" if have > max
+
+
+    rargs.each_with_index do |i,ri|
+      arguments[i].set args[ri]
+    end
+    
+    get_optionals.find_all do |i|
+      !rargs.index(i)
+    end.each do |i|
+      arguments[i].set nil
+    end
+    
+    get_omits.each do |i|
+      arguments[i].set nil
+    end
+    
+    if cb=arguments.find do |a|
+        a.callback
+      end
+      closure = b || @closure
+      cb.set closure
+    end
+    
+    invoked = []
+
+    pointers = arguments.map do |a|
+      ptr = a.for_invoke
+      
+      if a.value == nil
+        # do not wrap nil, pass it as is !
+        incoked << nil
+      else
+        if a.direction != :in
+          invoked << ptr.addr
+        else
+          invoked << ptr
+        end
+      end
+      ptr
+    end
+
+    # call the function
+    r = CFunc::libcall2(get_return_type,@where,@name.to_s,*invoked)
+
+    len = 1
+    if ary = @return_type.array
+      len = ary.fixed_size
+    end
+
+    # get the proper ruby value of return
+    result = (@return_type.type == :void ? nil : @return_type.to_ruby(r,len))
+
+    arguments.each do |a|
+      a[:value] = nil
+    end
+
+    if @results == [-1]
+
+      # default is to return array of out pointers and return value
+      ra = get_args_to_return().map do |a|
+        ptr = pointers[a.index] if @name == "g_spawn_command_line_sync"
+
+        len = 1
+        
+        if ary = a.array
+          
+          len = ary.fixed_size
+        end
+        
+        a.to_ruby(ptr,len)
+      end 
+           
+      r=[result].push(*ra)
+
+      case r.length
+      when 0
+        return nil
+      when 1
+        return r[0]
+      else
+        return r
+      end
+    else
+      # specify what to return.
+      # when returning out pointer of array, find the length from another out pointer 
+      qq = []
+      ala = @results.find_all do |q| q.is_a? Array end
+      
+      n = ala.map do |a|
+        arguments[a[0]]
+      end
+      
+      arguments.find_all do |a|
+        !n.index(a)
+      end.each do |a|
+        i=arguments.index(a)
+        qq[i] = a.to_ruby(pointers[i]) if @results.index(i)
+      end
+      
+      ala.each do |q|
+        qq[q[0]] = arguments[q[0]].to_ruby pointers[q[0]],qq[q[1]]
+      end
+      
+      a = []
+      @results.each do |i|
+        if i == -1
+          a << result
+        else
+          if i.is_a? Array
+            a << qq[i[0]]
+          else
+            a << qq[i]
+          end
+        end
+      end
+      a
+      case a.length
+      when 0
+        return nil
+      when 1
+        return a[0]
+      else
+        return a
+      end      
+    end
+  end
+end
+
+class Function
+  def pp
+    t = @return_type.type
+    case t
+    when :array
+      t = @return_type.array.type
+    when :object
+      t = @return_type.object
+    when :struct
+      t = @return_type.struct
+    end  
+    puts "#{ljust(@where)} #{ljust(@name)}"
+    puts "#{ljust(t)} #{@return_type.array ? "1" : "0"}"
+  
+   arguments.each do |a|
+    t = a.type
+    case a.type
+    when :array
+      t = a.array.type
+    when :object
+      t = a.object
+    when :struct
+      t = a.struct
+    end
+    puts "#{ljust(t)} #{a.array ? "1" : "0"}  #{a.direction} #{a.omit? ? "1" : "0"} #{a.callback ? "1" : "0"} #{}"
+   end
+  end
+end
+
+def ljust s
+  s=s.to_s
+  max = 35
+  take = nil
+  add = max-s.length
+  return s if add == 0
+  if add < 0
+    return s[0..s.length-1-add]
+  else
+    return s+(" "*add)
+  end
+end
+
+
+def add_function where,name,at,rt,ret=[-1]
+i=0
+  args = at.map do |a|
+  
+    arg=Argument.new
+    arg[:index] = i
+    i=i+1
+    direction,array,type,error,callback,data,allow_null = :in,false,:pointer,false,false,false ,false 
+    
+    while a.is_a?(Hash)
+      case a.keys[0]
+      when :out
+        direction = :out
+      when :inout
+        direction = :inout
+      when :allow_null
+        allow_null = true
+      when :callback
+        callback = a[a.keys[0]]
+      else
+      end
+      
+      a = a[a.keys[0]]
+    end
+    
+    if a.is_a? Array
+      array = ArrayStruct.new
+      arg[:array][:type] = a[0]
+      a = :array
+    end
+    
+
+    type = a
+    arg[:type] = type    
+    arg[:direction] = direction
+    arg[:allow_null] = allow_null
+    arg[:callback] = callback
+    arg
+  end
+  
+  interface = false
+  array = false
+  object = false
+  
+  rett = Return.new
+  
+  while rt.is_a? Hash
+    case rt.keys[0]
+    when :struct
+      rett[:struct] = rt[rt.keys[0]]
+      rett[:type] = :struct
+      rt = nil
+    when :object
+      rett[:object] = rt[rt.keys[0]]
+      rett[:type] = :object
+      rt = nil
+    end
+    rt = rt[rt.keys[0]]
+  end
+  
+  if rt.is_a? Array
+    ret[:type] = :array
+    ret[:array] = ArrayStruct.new
+    ret[:array][:type] = rt[0]
+  elsif rt
+    rett[:type] = rt
+  end
+  
+  Function.new(where,name,args,rett,ret)
+end
+
+
+

--- a/src/cfunc.c
+++ b/src/cfunc.c
@@ -18,13 +18,28 @@
 #include "mruby/dump.h"
 
 #include <setjmp.h>
-
+#include <errno.h>
 
 mrb_value
 cfunc_mrb_state(mrb_state *mrb, mrb_value klass)
 {
     return cfunc_pointer_new_with_pointer(mrb, mrb, false);
 }
+
+mrb_value
+cfunc_errno(mrb_state *mrb, mrb_value klass)
+{
+    return mrb_fixnum_value(errno);
+}
+
+mrb_value
+cfunc_strerror(mrb_state *mrb, mrb_value klass)
+{
+    mrb_value msg;
+    msg = mrb_str_new_cstr(mrb, strerror(errno));
+    return msg;
+}
+
 
 void
 mrb_mruby_cfunc_gem_init(mrb_state* mrb)
@@ -44,6 +59,8 @@ mrb_mruby_cfunc_gem_init(mrb_state* mrb)
 	init_cfunc_platform(mrb, ns); mrb_gc_arena_restore(mrb, ai);
 
     mrb_define_class_method(mrb, ns, "mrb_state", cfunc_mrb_state, ARGS_NONE());
+    mrb_define_class_method(mrb, ns, "errno", cfunc_errno, ARGS_NONE());
+    mrb_define_class_method(mrb, ns, "strerror", cfunc_strerror, ARGS_NONE());
 }
 
 void

--- a/src/cfunc_type.c
+++ b/src/cfunc_type.c
@@ -311,6 +311,30 @@ cfunc_uint64_class_get(mrb_state *mrb, mrb_value klass)
 
 
 mrb_value
+cfunc_uint64_divide(mrb_state *mrb, mrb_value self)
+{
+    mrb_value mdivider;
+    mrb_int divider;
+    uint64_t result;
+    struct cfunc_type_data *data = (struct cfunc_type_data*)DATA_PTR(self);
+    uint64_t uint64 = data->value._uint64;
+    if(data->refer) {
+        uint64 = *(uint64_t*)data->value._pointer;
+    }
+    
+    mrb_get_args(mrb, "o", &mdivider);
+    divider = mrb_fixnum(mdivider);    
+    result = uint64 / divider;
+    
+    if(result > UINT32_MAX) {
+        mrb_raise(mrb, E_TYPE_ERROR, "result too big.");
+    }
+    
+    return int64_to_mrb( uint64 / divider );
+}
+
+
+mrb_value
 cfunc_uint64_get_value(mrb_state *mrb, mrb_value self)
 {
     struct cfunc_type_data *data = (struct cfunc_type_data*)DATA_PTR(self);
@@ -627,6 +651,7 @@ void init_cfunc_type(mrb_state *mrb, struct RClass* module)
     mrb_define_method(mrb, uint64_class, "high", cfunc_uint64_get_high, ARGS_NONE());
     mrb_define_method(mrb, uint64_class, "high=", cfunc_uint64_set_high, ARGS_REQ(1));
     mrb_define_method(mrb, uint64_class, "to_s", cfunc_uint64_to_s, ARGS_REQ(1));
+    mrb_define_method(mrb, uint64_class, "divide", cfunc_uint64_divide, ARGS_REQ(1));
     DONE;
     
     // sint64 specific

--- a/test/ffi.rb
+++ b/test/ffi.rb
@@ -1,0 +1,26 @@
+mobiruby_test "FFI::MemoryPointer(:int)" do
+  num = FFI::MemoryPointer.new(:int)
+
+  num.write_int(0)
+  assert_equal num.read_int(), 0
+  
+  num.write_int(42)
+  assert_equal num.read_int(), 42
+
+end
+
+mobiruby_test "FFI::MemoryPointer(:string)" do
+  num = FFI::MemoryPointer.new(5)
+
+  num.write_string("A string")
+  assert_equal(num.read_string(), "A string")
+end
+
+mobiruby_test "FFI::MemoryPointer(array of int)" do
+  arr = FFI::MemoryPointer.new(:int, 3)
+  arr.write_array_of_int([1, 2, 3])
+  
+  assert_equal(arr.read_array_of_int(), [1,2,5])
+end
+
+


### PR DESCRIPTION
The code is ready to be merged but there is one thing to take car of before that:
how to add a proper way to set the location of includes/library ? (I had to hardcode mine in mrbgems.rake)

I started by extracting the abstraction in mruby-girffi and from there found multiple issues I fixed as well as missing apis or incorrect method signature, in its current state I have a yet to release gem taking advantage of this abstraction to make it works both as a mruby gem and as a mri gem which was my original goal.

I made sure a large part of the ruby ffi interface was implemented but not everything is of course but apis can be added as needed later.
