### PR TITLE
allow access to the fields object in structrures

### DIFF
--- a/mrblib/cfunc_rb.rb
+++ b/mrblib/cfunc_rb.rb
@@ -188,6 +188,11 @@ class CFunc::Struct
         self.new(pointer)
     end
     
+    def element(fieldname)
+        field = lookup(fieldname)
+        field[0].refer(@pointer.offset(field[2]))
+    end
+    
     def [](fieldname)
         field = lookup(fieldname)
         el = field[0].refer(@pointer.offset(field[2]))


### PR DESCRIPTION
helps mimic how ruby-ffi works when working with
structures.

I need that for the abstraction and would prefer avoiding monkey patching mruby-cfunc code in another gem.
