### PR TITLE
added UInt64.divide

### DIFF
--- a/src/cfunc_type.c
+++ b/src/cfunc_type.c
@@ -311,6 +311,30 @@ cfunc_uint64_class_get(mrb_state *mrb, mrb_value klass)
 
 
 mrb_value
+cfunc_uint64_divide(mrb_state *mrb, mrb_value self)
+{
+    mrb_value mdivider;
+    mrb_int divider;
+    uint64_t result;
+    struct cfunc_type_data *data = (struct cfunc_type_data*)DATA_PTR(self);
+    uint64_t uint64 = data->value._uint64;
+    if(data->refer) {
+        uint64 = *(uint64_t*)data->value._pointer;
+    }
+    
+    mrb_get_args(mrb, "o", &mdivider);
+    divider = mrb_fixnum(mdivider);    
+    result = uint64 / divider;
+    
+    if(result > UINT32_MAX) {
+        mrb_raise(mrb, E_TYPE_ERROR, "result too big.");
+    }
+    
+    return int64_to_mrb( uint64 / divider );
+}
+
+
+mrb_value
 cfunc_uint64_get_value(mrb_state *mrb, mrb_value self)
 {
     struct cfunc_type_data *data = (struct cfunc_type_data*)DATA_PTR(self);
@@ -627,6 +651,7 @@ void init_cfunc_type(mrb_state *mrb, struct RClass* module)
     mrb_define_method(mrb, uint64_class, "high", cfunc_uint64_get_high, ARGS_NONE());
     mrb_define_method(mrb, uint64_class, "high=", cfunc_uint64_set_high, ARGS_REQ(1));
     mrb_define_method(mrb, uint64_class, "to_s", cfunc_uint64_to_s, ARGS_REQ(1));
+    mrb_define_method(mrb, uint64_class, "divide", cfunc_uint64_divide, ARGS_REQ(1));
     DONE;
     
     // sint64 specific

--- a/test/uint64.rb
+++ b/test/uint64.rb
@@ -24,4 +24,21 @@ mobiruby_test "CFunc::UInt64" do
 
   uint = CFunc::UInt64.new(CFunc::SInt16.new(16))
   assert_equal 16, uint.value
+  
+  
+  # divide test
+  uint.low = 0xFFFFFFFF
+  uint.high = 0xFF
+  
+  err = nil
+  begin
+    uint.value
+  rescue => ex
+    err = ex
+  end
+  
+  assert_equal 'TypeError', err.class.to_s
+  assert_equal "too big. Use low, high", err.message
+  
+  assert_equal uint.divide(1000), 1099511627
 end


### PR DESCRIPTION
CFunc allow accessing UInt64 numbers by splitting them in two 32bits, this is another way to deal with them.

In my case I get an UInt64 storing a size in byte, dividing it by 1024 gives me Kb which is largely enough for my needs but allow it to be represented in mruby.
