### PR TITLE
reflect latest mruby API changes

### DIFF
--- a/src/cfunc_rubyvm.c
+++ b/src/cfunc_rubyvm.c
@@ -247,8 +247,7 @@ cfunc_rubyvm_open(void *args)
     init_cfunc_module(mrb);
 #endif
 
-    mrb_irep* irep;
-    irep = mrb_add_irep(mrb);
+    mrb_irep* irep = mrb_read_irep(mrb, data->mrb_data);
 
     mrb_run(mrb, mrb_proc_new(mrb, irep), mrb_top_self(mrb));
 

--- a/src/cfunc_rubyvm.c
+++ b/src/cfunc_rubyvm.c
@@ -247,9 +247,10 @@ cfunc_rubyvm_open(void *args)
     init_cfunc_module(mrb);
 #endif
 
-    int n = mrb_read_irep(mrb, data->mrb_data);
+    mrb_irep* irep;
+    irep = mrb_add_irep(mrb);
 
-    mrb_run(mrb, mrb_proc_new(mrb, mrb->irep[n]), mrb_top_self(mrb));
+    mrb_run(mrb, mrb_proc_new(mrb, irep), mrb_top_self(mrb));
 
     if (mrb->exc) {
         return NULL;


### PR DESCRIPTION
`mrb_state` no longer has member `irep`
